### PR TITLE
Update to OBS websocket v5 proctol; scuttle <= v4

### DIFF
--- a/README.org
+++ b/README.org
@@ -32,15 +32,15 @@ Here's my config. It uses use-package and hydra.
   (defhydra my/obs-websocket (:exit t)
     "Control Open Broadcast Studio"
     ("c" (obs-websocket-connect) "Connect")
-    ("d" (obs-websocket-send "SetCurrentScene" :scene-name "Desktop") "Desktop")
-    ("e" (obs-websocket-send "SetCurrentScene" :scene-name "Emacs") "Emacs")
-    ("i" (obs-websocket-send "SetCurrentScene" :scene-name "Intermission") "Intermission")
+    ("d" (obs-websocket-send "SetCurrentProgramScene" :scene-name "Desktop") "Desktop")
+    ("e" (obs-websocket-send "SetCurrentProgramScene" :scene-name "Emacs") "Emacs")
+    ("i" (obs-websocket-send "SetCurrentProgramScene" :scene-name "Intermission") "Intermission")
     ("v" (browse-url "https://twitch.tv/sachachua"))
     ("m" my/twitch-message "Message")
     ("t" my/twitch-message "Message")
     ("<f8>" my/twitch-message "Message") ;; Then I can just f8 f8
-    ("sb" (obs-websocket-send "StartStreaming") "Stream - begin")
-    ("se" (obs-websocket-send "StopStreaming") "Stream - end"))
+    ("sb" (obs-websocket-send "StartStream") "Stream - begin")
+    ("se" (obs-websocket-send "StopStream") "Stream - end"))
   (global-set-key (kbd "<f8>") #'my/obs-websocket/body)
   :load-path "~/code/obs-websocket-el" :ensure nil)
 #+end_src
@@ -66,10 +66,10 @@ Here is another config option using =use-package= and =transient= features stand
     ["Streaming"
      ("sb" "Stream - begin"
       (lambda () (interactive)
-        (obs-websocket-send "StartStreaming")))
+        (obs-websocket-send "StartStream")))
      ("se" "Stream - end"
       (lambda () (interactive)
-        (obs-websocket-send "StopStreaming")))]
+        (obs-websocket-send "StopStream")))]
     ["Scenes"
      ("d" "Desktop"
       (lambda () (interactive)

--- a/README.org
+++ b/README.org
@@ -1,5 +1,5 @@
 * obs-websocket-el
-  
+
 Totally bubblegum-and-string at the moment.
 
 You'll need [[https://obsproject.com/][Open Broadcaster Software]] and the [[https://obsproject.com/forum/resources/obs-websocket-remote-control-obs-studio-from-websockets.466/][obs-websocket]] plugin for
@@ -45,9 +45,52 @@ Here's my config. It uses use-package and hydra.
   :load-path "~/code/obs-websocket-el" :ensure nil)
 #+end_src
 
-Better installation instructions will eventually be written by
-someone, if anyone wants to actually maintain this. 
+Here is another config option using =use-package= and =transient= features standard in Emacs 30:
 
-Protocol reference: https://github.com/Palakis/obs-websocket/blob/4.x-current/docs/generated/protocol.md
+#+begin_src emacs-lisp
+(use-package websocket
+  :ensure t
+  :defer t)
+
+(use-package obs-websocket
+  :ensure t
+  :after (websocket)
+  :vc (:url "https://github.com/sachac/obs-websocket-el.git"
+            :rev :newest)
+  :bind (("<f8>" . my/obs-websocket-tmenu))
+  :config
+  (transient-define-prefix my/obs-websocket-tmenu ()
+    "Transient menu for controlling OBS via websocket"
+    ["Connection"
+     ("c" "Connect to OBS" obs-websocket-connect)]
+    ["Streaming"
+     ("sb" "Stream - begin"
+      (lambda () (interactive)
+        (obs-websocket-send "StartStreaming")))
+     ("se" "Stream - end"
+      (lambda () (interactive)
+        (obs-websocket-send "StopStreaming")))]
+    ["Scenes"
+     ("d" "Desktop"
+      (lambda () (interactive)
+        (obs-websocket-send "SetCurrentProgramScene" :sceneName "Desktop")))
+     ("e" "Emacs"
+      (lambda () (interactive)
+        (obs-websocket-send "SetCurrentProgramScene" :sceneName "Emacs")))
+     ("i" "Intermission"
+      (lambda () (interactive)
+        (obs-websocket-send "SetCurrentProgramScene" :sceneName "Intermission")))
+     ("v" "Browse Channel"
+      (lambda () (interactive)
+        (browse-url "https://twitch.tv/<your-channel-here>")))
+     ]))
+#+end_src
+
+
+Better installation instructions will eventually be written by
+someone, if anyone wants to actually maintain this.
+
+Protocol reference: [[https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md][5.x.x Websocket Protocol Reference]]
+
 
 My e-mail address is [[sacha@sachachua.com]], although I tend to reply slowly.

--- a/obs-websocket.el
+++ b/obs-websocket.el
@@ -26,14 +26,14 @@
 ;;
 ;; You will also need to install:
 ;; OBS: https://obsproject.com/
-;; obs-websocket: https://github.com/Palakis/obs-websocket
+;; obs-websocket: https://github.com/obsproject/obs-websocket
 ;; websocket.el: https://github.com/ahyatt/emacs-websocket
 
 ;;; Code:
 
 (require 'websocket)
 (require 'json)
-(defvar obs-websocket-url "ws://localhost:4444" "URL for OBS instance. Use wss:// if secured by TLS.")
+(defvar obs-websocket-url "ws://localhost:4455" "URL for OBS instance. Use wss:// if secured by TLS.")
 (defvar obs-websocket-password nil "Password for OBS.")
 (defvar obs-websocket nil "Socket for communicating with OBS.")
 (defvar obs-websocket-messages nil "Messages from OBS.")

--- a/obs-websocket.el
+++ b/obs-websocket.el
@@ -196,7 +196,12 @@ plist."
 
 (defun obs-websocket-on-close (&rest args)
   "Display a message when the connection has closed."
-  (setq obs-websocket nil)
+  (setq obs-websocket nil
+        obs-websocket-scene nil
+        obs-websocket-status "")
+  (unless obs-websocket-debug
+    (setq obs-websocket-messages nil))
+  (obs-websocket-update-mode-line)
   (message "OBS connection closed."))
 
 (defun obs-websocket-send (request-type &rest args)

--- a/obs-websocket.el
+++ b/obs-websocket.el
@@ -116,8 +116,10 @@
              )))
       (when msg (message "OBS: %s" msg)))))
 
-(cl-defun obs--auth-string (&key salt challenge password &allow-other-keys)
-  "Creates an OBS-expected authentication string from"
+(cl-defun obs-websocket--auth-string
+    (&key salt challenge password &allow-other-keys)
+  "Creates an OBS-expected authentication string from an `:authentication'
+plist."
   (cl-flet ((obs-encode (string-1 string-2)
               (base64-encode-string
                (secure-hash 'sha256 (concat string-1 string-2) nil nil t))))
@@ -129,7 +131,8 @@
   (when-let ((auth-data (plist-get payload :authentication)))
     (let* ((password (or obs-websocket-password
                          (read-passwd "OBS websocket password:")))
-           (auth (apply #'obs--auth-string (append auth-data (list :password password)))))
+           (auth (apply #'obs-websocket--auth-string
+                        (append auth-data (list :password password)))))
       (when obs-websocket-debug
         (push (list :authenticating auth) obs-websocket-messages))
       (obs-websocket-send-identify auth))))

--- a/obs-websocket.el
+++ b/obs-websocket.el
@@ -149,11 +149,10 @@
 
 (defun obs-websocket-on-message (websocket frame)
   "Handle OBS WEBSOCKET sending FRAME."
+  (when obs-websocket-debug
+    (setq obs-websocket-messages (cons frame obs-websocket-messages)))
   (let* ((payload (json-parse-string (websocket-frame-payload frame)
                                      :object-type 'plist :array-type 'list)))
-    (when obs-websocket-debug
-      (setq obs-websocket-messages (cons frame obs-websocket-messages)))
-
     (run-hook-with-args 'obs-websocket-on-message-payload-functions payload)))
 
 (defun obs-websocket-on-close (&rest args)

--- a/obs-websocket.el
+++ b/obs-websocket.el
@@ -181,16 +181,16 @@ plist."
            (push (list :requestResponse payload) obs-websocket-messages))
          (let ((request-id (plist-get message-data :requestId))
                (request-status (plist-get message-data :requestStatus)))
-           ;; TODO: Handle errors in request-status
-           ;; if (and (equal (plist-get payload :status) "error"))
-           ;; (error "OBS: %s" (plist-get payload :error))
-           (when-let ((callback (assoc request-id obs-websocket-message-callbacks)))
-             (catch 'err
-               (funcall (cdr callback) message-data))
-             (setf obs-websocket-message-callbacks
-                   (assoc-delete-all request-id obs-websocket-message-callbacks)))))
-      ;; (t (when obs-websocket-debug
-      ;;      (push (list :unhandled payload) obs-websocket-messages)))
+           (if (eq (plist-get request-status :result) :false)
+               (error "OBS: Error code %d -- %s"
+                      (plist-get request-status :code)
+                      (plist-get request-status :comment))
+             (when-let ((callback (assoc request-id obs-websocket-message-callbacks)))
+               (catch 'err
+                 (funcall (cdr callback) message-data))
+               (setf obs-websocket-message-callbacks
+                     (assoc-delete-all request-id obs-websocket-message-callbacks))))))
+      ;;TODO: Handle opcodes 8 and 9
       )))
 
 (defun obs-websocket-on-message (websocket frame)

--- a/obs-websocket.el
+++ b/obs-websocket.el
@@ -41,7 +41,7 @@
 (defvar obs-websocket-rpc-version 1 "Lastest OBS RPC version supported.")
 (defvar obs-websocket-obs-websocket-version nil "Connected OBS' Web Socket Version")
 (defvar obs-websocket-obs-studio-version nil "Connected OBS' Studio Version")
-(defvar obs-websocket-on-message-payload-functions '(obs-websocket-marshall-message)
+(defvar obs-websocket-on-message-payload-functions '(obs-websocket-marshal-message)
   "Functions to call when messages arrive.")
 (defvar obs-websocket-debug nil "Debug messages")
 (defvar obs-websocket-message-callbacks nil "Alist of (message-id . callback-func)")
@@ -164,7 +164,7 @@ plist."
                           (obs-websocket-update-mode-line))))
   (obs-websocket-minor-mode 1))
 
-(defun obs-websocket-marshall-message (payload)
+(defun obs-websocket-marshal-message (payload)
   (let ((opcode (plist-get payload :op))
         (message-data (plist-get payload :d)))
     (cl-check-type opcode (integer 0 *) "positive integer op code expected")

--- a/obs-websocket.el
+++ b/obs-websocket.el
@@ -1,6 +1,7 @@
 ;;; obs-websocket.el --- Interact with Open Broadcaster Software through a websocket   -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2021  Sacha Chua
+;; Copyright (C) 2025  Charlie McMackin
 
 ;; Author: Sacha Chua <sacha@sachachua.com>
 ;; Keywords: recording streaming

--- a/obs-websocket.el
+++ b/obs-websocket.el
@@ -63,7 +63,8 @@
                       (if obs-websocket-recording-p "Rec" "")
                       "*")
                    ""))))
-    (setq obs-websocket-status info)))
+    (setq obs-websocket-status info)
+    (force-mode-line-update)))
 
 (define-minor-mode obs-websocket-minor-mode
   "Minor mode for OBS Websocket."


### PR DESCRIPTION
## Purposely breaks support for protocol version less than 5
V5 became built in with OBS version 28 approximately 3 years ago. Since v5 added protocol versioning, especially with its RPC versioning, I hope it's ok to just outright remove v4 support.

## Add support for OBS websocket protcol v5, RPC v1
The main changes are:
1. Implementing the new authentication flow
2. Changing the event, request, and response names as needed.
3. Explicitly marshaling the OBS events and responses by their OpCodes, not using the `obs-websocket-on-message-payload-functions` hooks.
4. Updating README links and adding a transient menu config example for Emacs 30+ (mainly because of the `:vc` option of `use-package`)

This is a "quickest path to V5 support while keeping previous functionality" PR. The OpCodes are dispatched in a "magic number" fashion (i.e. no well-named constants.) Likewise the request objects sent to the server are constructed with magic number op codes.

I've tested it with local recording but not yet starting and stopping a stream